### PR TITLE
Add validate_features option for Booster predict

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1033,7 +1033,7 @@ class Booster(object):
 
         validate_features : bool
             When this is True, validate that the Booster's and data's feature_names are identical.
-            Otherwise, it is assumed that the feature_names are the same. 
+            Otherwise, it is assumed that the feature_names are the same.
 
         Returns
         -------

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -988,7 +988,8 @@ class Booster(object):
         return self.eval_set([(data, name)], iteration)
 
     def predict(self, data, output_margin=False, ntree_limit=0, pred_leaf=False,
-                pred_contribs=False, approx_contribs=False, pred_interactions=False):
+                pred_contribs=False, approx_contribs=False, pred_interactions=False,
+                validate_features=True):
         """
         Predict with data.
 
@@ -1030,6 +1031,10 @@ class Booster(object):
             pred_contribs), and the sum of the entire matrix equals the raw untransformed margin
             value of the prediction. Note the last row and column correspond to the bias term.
 
+        validate_features : bool
+            When this is True, validate that the Booster's and data's feature_names are identical.
+            Otherwise, it is assumed that the feature_names are the same. 
+
         Returns
         -------
         prediction : numpy array
@@ -1046,7 +1051,8 @@ class Booster(object):
         if pred_interactions:
             option_mask |= 0x10
 
-        self._validate_features(data)
+        if validate_features:
+            self._validate_features(data)
 
         length = c_bst_ulong()
         preds = ctypes.POINTER(ctypes.c_float)()


### PR DESCRIPTION
@afavaro @jtcho @ylwu 

This is the one and only reason why we're forking xgboost. Online predictions are really slow compared to the current ones otherwise. Hooray.

I would add tests as soon as I figure out 1) where they are and 2) how to run them.

(There's an [old xgboost PR](https://github.com/dmlc/xgboost/pull/2536/files) that attempted to add this option, but it's since been closed. Hooray.) 

cc @elibingham @k-nitesh @garrett-schlesinger 